### PR TITLE
feat!: bump min elixir version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,14 @@ jobs:
     strategy:
       matrix:
         otp: [23.x, 24.x, 25.x]
-        elixir: [1.10.x, 1.11.x, 1.12.x, 1.13.x, 1.14.x]
+        elixir: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
         exclude:
           - otp: 25.x
             elixir: 1.11.x
           - otp: 25.x
             elixir: 1.12.x
-          - otp: 25.x
-            elixir: 1.10.x
-          - otp: 24.x
-            elixir: 1.10.x
+          - otp: 23.x
+            elixir: 1.15.x
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/gen_lsp.ex
+++ b/lib/gen_lsp.ex
@@ -26,7 +26,7 @@ defmodule GenLSP do
 
       @impl true
       def handle_info(_, state) do
-        Logger.warn("Unhandled message passed to handle_info/2")
+        Logger.warning("Unhandled message passed to handle_info/2")
 
         {:noreply, state}
       end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule GenLSP.MixProject do
       description: "Library for creating language servers",
       source_url: @source_url,
       version: "0.2.1",
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
The next-ls server reported the following warning: `Elixir: Logger.warn/1 is deprecated. Use Logger.warning/2 instead`.

This is only support since Elixir 1.11.0 I believe and the mix.ex has elixir "~> 1.10", but think this might be a bit old to support. 