### PR TITLE
fix: stop `erts` when end of input is reached

### DIFF
--- a/lib/gen_lsp/buffer.ex
+++ b/lib/gen_lsp/buffer.ex
@@ -127,6 +127,7 @@ defmodule GenLSP.Buffer do
         fn buffer ->
           case comm.read(comm_data, buffer) do
             :eof ->
+              System.stop()
               {:halt, :ok}
 
             {:error, reason} ->


### PR DESCRIPTION
This ensures that the runtime will shut down if input is closed, eliminating zombie processes that are left when an explicit "shutdown" message isn't sent to the LS.

I elected to use `System.stop/1` instead of `System.halt/1` since a [careful shutdown of the system](https://hexdocs.pm/elixir/1.15.7/System.html#halt/1) seemed preferable.

## Testing

I tested the change by replacing the `gen_lsp` dependency in `next-ls` with my local version, which includes the change, and comparing the behavior of sending an "End of Transmission" event to a running `next-ls` instance (started with `bin/start --stdio`).

### Before the change

Running `epmd -names | wc -l` after starting the server produced `11` (from zombies already on my machine, plus the new server). Without adding the `System.stop/1` call and sending an EOT using `^D` the server does not stop. 

### After the change

Running `epmd -names | wc -l` after starting the server produced `11`. Sending an EOT using `^D` causes the server to stop, and a subsequent execution of `epmd -names | wc -l` produces `10`. 