### PR TITLE
fix: protect String.split from >2 parts

### DIFF
--- a/lib/gen_lsp/communication/stdio.ex
+++ b/lib/gen_lsp/communication/stdio.ex
@@ -74,7 +74,7 @@ defmodule GenLSP.Communication.Stdio do
             read_header(headers)
 
           line ->
-            [k, v] = String.split(line, ":")
+            [k, v] = String.split(line, ":", parts: 2)
             read_header(Map.put(headers, String.trim(k), String.trim(v)))
         end
     end


### PR DESCRIPTION
While editing in VSCode, I was able to get an embedded `:` in the value
part of the line. This would cause an exception and make it hard to
save. This change restricts the max number of parts to protect against
this.
