### PR TITLE
fix: handle document lifecycle notifications synchronously

### DIFF
--- a/lib/gen_lsp/lsp.ex
+++ b/lib/gen_lsp/lsp.ex
@@ -11,6 +11,7 @@ defmodule GenLSP.LSP do
     field :pid, pid()
     field :tasks, %{integer() => pid()}
     field :task_supervisor, atom() | pid()
+    field :sync_notifications, MapSet.t(module())
   end
 
   @spec assign(t(), Keyword.t() | (map() -> keyword())) :: t()

--- a/test/support/ordering_server.ex
+++ b/test/support/ordering_server.ex
@@ -1,0 +1,47 @@
+defmodule GenLSPTest.OrderingServer do
+  use GenLSP
+  alias GenLSP.Notifications
+  alias GenLSP.Requests
+  alias GenLSP.Structures
+
+  def start_link(opts) do
+    {test_pid, opts} = Keyword.pop!(opts, :test_pid)
+    {order_agent, opts} = Keyword.pop!(opts, :order_agent)
+    GenLSP.start_link(__MODULE__, {test_pid, order_agent}, opts)
+  end
+
+  @impl true
+  def init(lsp, {test_pid, order_agent}) do
+    {:ok, assign(lsp, test_pid: test_pid, order_agent: order_agent)}
+  end
+
+  @impl true
+  def handle_request(%Requests.Initialize{}, lsp) do
+    {:reply,
+     %Structures.InitializeResult{
+       capabilities: %Structures.ServerCapabilities{},
+       server_info: %{name: "Ordering Test Server"}
+     }, lsp}
+  end
+
+  @impl true
+  def handle_notification(%Notifications.TextDocumentDidOpen{} = note, lsp) do
+    Agent.update(assigns(lsp).order_agent, fn list -> list ++ [:did_open] end)
+    send(assigns(lsp).test_pid, {:callback, note})
+    {:noreply, lsp}
+  end
+
+  @impl true
+  def handle_notification(%Notifications.TextDocumentDidChange{} = note, lsp) do
+    Agent.update(assigns(lsp).order_agent, fn list -> list ++ [:did_change] end)
+    send(assigns(lsp).test_pid, {:callback, note})
+    {:noreply, lsp}
+  end
+
+  @impl true
+  def handle_notification(%Notifications.TextDocumentDidClose{} = note, lsp) do
+    Agent.update(assigns(lsp).order_agent, fn list -> list ++ [:did_close] end)
+    send(assigns(lsp).test_pid, {:callback, note})
+    {:noreply, lsp}
+  end
+end


### PR DESCRIPTION
Fixes a race condition issue found while debugging https://github.com/elixir-lang/expert/issues/245

In some editors(I can realiably reproduce on neovim) the client will send `textDocument/didOpen` and immediately after `textDocument/didClose` which causes a lot of issues with Expert's Document store, and it's not trivial to fix there.

Both Lexical and ElixirLS handle the specific notifications in this PR synchronously to ensure they are handled in order, per the spec.

This PR fixes that by handling lifecycle notifications synchronously. I also made the sync notifications configurable in case users have different requirements. I don't personally see which or how, but it wasn't hard to add.

